### PR TITLE
의존성 설치 문제를 수정합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@react-navigation/native": "^6.0.8",
     "@react-navigation/native-stack": "^6.5.0",
     "@react-navigation/stack": "^6.1.1",
-    "@unimodules/react-native-adapter": "^6.3.9",
+    "@unimodules/react-native-adapter": "~6.5.0",
     "eas-cli": "^0.47.0",
     "expo": "~44.0.0",
     "expo-dev-client": "~0.8.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "@expo/vector-icons": "expo/vector-icons",
+    "@expo/vector-icons": "^12.0.5",
     "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-community/datetimepicker": "4.0.0",
     "@react-native-community/masked-view": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@react-navigation/native-stack": "^6.5.0",
     "@react-navigation/stack": "^6.1.1",
     "@unimodules/react-native-adapter": "~6.5.0",
-    "eas-cli": "^0.47.0",
     "expo": "~44.0.0",
     "expo-dev-client": "~0.8.4",
     "expo-status-bar": "~1.2.0",


### PR DESCRIPTION
* `@expo/vector-icons` 관련 설치 문제를 해결합니다.
* `eas-cli`는 global로 설치해서 로컬에서 사용하면 될 것 같습니다. 프로젝트의 의존성으로는 필요가 없습니다.