### PR TITLE
불필요한 안드로이드 권한 제거

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,7 +26,8 @@
       },
       "userInterfaceStyle": "automatic",
       "package": "com.sungho0205.geupsik",
-      "versionCode": 100
+      "versionCode": 101,
+      "permissions": []
     },
     "web": {
       "favicon": "./assets/favicon.png"


### PR DESCRIPTION
`android.permissions`를 빈배열로 설정하지 않으면, 기본적으로 모든 안드로이드 권한이 추가되어서 스토어에 배포 시 문제가 발생하여 수정합니다.