### PR TITLE
fix: useEffect의 clean up 함수 추가

### DIFF
--- a/src/screens/GeupsikScreen.js
+++ b/src/screens/GeupsikScreen.js
@@ -249,6 +249,11 @@ export default function GeupsikScreen({ navigation }) {
         setApiLoadingState(loading.error);
         console.log(error);
       });
+
+    return () => {
+      setApiLoadingState(loading.beforeLoading);
+      setData(["급식을 가져오는 중입니다."]);
+    }
   }, [text]);
 
   const styles = StyleSheet.create({


### PR DESCRIPTION
useEffect의 의존성 배열에 포함된 `text` 값이 변경 될 때마다 useEffect 훅 안에 API 통신이 일어나는데요. useEffect의 clean up 함수를 사용하여, fetch 전에 data, apiLoadingState를 돌려놓도록 하였습니다.